### PR TITLE
Database split

### DIFF
--- a/activity-tracking/config.json
+++ b/activity-tracking/config.json
@@ -1,4 +1,5 @@
 {
-    "mongoUri": "mongodb://root:cfgmla23@mongodb:27017"
+    "mongoUri": "mongodb://root:cfgmla23@mongodb:27017",
+    "mongoDb": "activity"
   }
   

--- a/activity-tracking/server.js
+++ b/activity-tracking/server.js
@@ -6,8 +6,9 @@ require('dotenv').config();
 
 const app = express();
 const port = process.env.PORT || 5300;
-const uri = process.env.MONGODB_URI;
-const mongoUri = config.mongoUri;
+const baseUri = process.env.MONGO_URI || config.mongoUri;
+const database = process.env.MONGO_DB || config.mongoDb;
+const mongoUri = `${baseUri}/${database}?authsource=admin`;
 
 // Middleware setup
 app.use(cors());

--- a/analytics/.env
+++ b/analytics/.env
@@ -1,2 +1,2 @@
-MONGO_URI = "mongodb://root:cfgmla23@localhost:27017"
-MONGO_DB = "test"
+MONGO_URI = "mongodb://root:cfgmla23@mongodb:27017"
+MONGO_DB = "activity"

--- a/authservice/src/main/resources/application.properties
+++ b/authservice/src/main/resources/application.properties
@@ -1,4 +1,4 @@
 logging.level.org.springframework=DEBUG
 logging.level.com.authservice=DEBUG
-spring.data.mongodb.database=test
-spring.data.mongodb.uri=mongodb://root:cfgmla23@localhost:27017
+spring.data.mongodb.database=authservice
+spring.data.mongodb.uri=mongodb://root:cfgmla23@mongodb:27017

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       dockerfile: Dockerfile
     environment:
       - NODE_ENV=development
+      - MONGO_DB=activity
+      - MONGO_URI=mongodb://root:cfgmla23@mongodb:27017
     ports:
       - "5300:5300"
     depends_on:
@@ -28,6 +30,7 @@ services:
       dockerfile: Dockerfile
     environment:
       - NODE_ENV=development
+      - MONGO_DB=activity
       - MONGO_URI=mongodb://root:cfgmla23@mongodb:27017
     ports:
       - "5050:5050"
@@ -41,7 +44,7 @@ services:
       context: ./authservice
       dockerfile: Dockerfile
     environment:
-      - SPRING_DATA_MONGODB_DATABASE=test
+      - SPRING_DATA_MONGODB_DATABASE=authservice
       - SPRING_DATA_MONGODB_URI=mongodb://root:cfgmla23@mongodb:27017
     ports:
       - "8080:8080"


### PR DESCRIPTION
This changes creates two new MongoDB databases - called activity and authservice - to replace the single database that was there (test). Each of the two microservices (activity tracking and authservice) now have their own databases (as shown below).

![image](https://github.com/Raji-bhaskaran/MLA-pilot---GRP3/assets/158090679/08a5e53f-f17f-4fb3-8580-09a6f8957e2b)

I have tested this locally by adding a new user and by adding new activities and checking that the data appears in the relevant collection in each database.
